### PR TITLE
Drop prerelease version suffix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "double-ended-queue",
     "description": "Extremely fast double-ended queue implementation",
-    "version": "2.1.0-0",
+    "version": "2.1.0",
     "keywords": [
         "data-structure",
         "data-structures",


### PR DESCRIPTION
Six months should be long enough to be confident this release is safe, don't you think? :)

This came up because of a bug involving `npm`, `semver`, `read-installed`, and prerelease packages: https://github.com/npm/read-installed/issues/40

If you decide to accept this commit, please publish a new release to NPM as soon as possible. Thanks!